### PR TITLE
Fix url in google font import

### DIFF
--- a/css/gumby.css
+++ b/css/gumby.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
 /**
 * Gumby Framework
 * ---------------

--- a/sass/_fonts.scss
+++ b/sass/_fonts.scss
@@ -1,7 +1,7 @@
 /* Fonts */
 
 // Import Google Web Fonts
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
 
 
 // Set local icon font


### PR DESCRIPTION
In SSL conection some browser block the download because the request of google font use http protocol. This solution solves importing font in both schemes, http and https.
