### PR TITLE
Tabs inside tabs

### DIFF
--- a/js/libs/ui/gumby.tabs.js
+++ b/js/libs/ui/gumby.tabs.js
@@ -8,8 +8,10 @@
 	function Tabs($el) {
 
 		this.$el = $el;
-		this.$nav = this.$el.find('ul.tab-nav > li');
-		this.$content = this.$el.find('.tab-content');
+    this.$nav = this.$el.find('ul.tab-nav > li' +
+      ($el.data("tabSet") ? '[tabSet="'+$el.data('tabSet')+'"]' : ''));
+    this.$content = this.$el.find( '.tab-content' +
+      ($el.data("tabSet") ? '[tabSet="'+$el.data('tabSet')+'"]' : ''));
 
 		var scope = this;
 
@@ -55,6 +57,8 @@
 			}
 			// mark element as initialized
 			$this.data('isTabs', true);
+      // store the tabSet name
+      $this.data('tabSet', this.getAttribute('tabSet'));
 			new Tabs($this);
 		});
 	});


### PR DESCRIPTION
I needed to have a group of tabs inside a pill tab group, so i made this change.

It's not pretty but it works quite well.

If the user wants to do this, all that is needed is to include a "tabSet" attribute in the tab group ul, li and tab-content divs.
For each group of tabs, give tabSet a different value.

Example:

``` html
<section class="tabs" tabSet='main'>
  <ul class="tab-nav">
    <li tabSet='main'><a href="#">Tab 1</a></li>
    <li tabSet='main' class="active"><a href="#">Tab 2</a></li>
    <li tabSet='main'><a href="#">Tab 3</a></li>
  </ul>
  <div tabSet='main' class="tab-content">
    <p>1</p>
  </div>
  <div tabSet='main' class="tab-content active">
    <p>2</p>
  </div>
  <div tabSet='main' class="tab-content">
    <p>3</p>
  </div>
</section>
```
