### PR TITLE
Box Shadow not being shown on 'photo image' in tiles

### DIFF
--- a/sass/ui/_images.scss
+++ b/sass/ui/_images.scss
@@ -11,11 +11,11 @@
     @include border-radius($button-radius $button-radius);
   }
   &.photo {
-    border: 5px solid #fff;
-    box-shadow: 0 0 1px $body-font-color; 
+    padding: 5px;
+    box-shadow: inset 0 0 1px $body-font-color;
+    background: #fff;
     &.polaroid {
       padding-bottom: 50px;
-      background: #fff;
     }
   }
 }


### PR DESCRIPTION
Changed box-shadow to inset so it's inside the element. Removed the 5px white border and replaced it with a white background and 5px padding.
