### PR TITLE
Fix/search field reset icon

### DIFF
--- a/sass/ui/_forms.scss
+++ b/sass/ui/_forms.scss
@@ -75,6 +75,7 @@ form {
     &.search {
       @include line-and-height(height-calc($norm));
       @include border-radius(1000px);
+      padding-right: 0;
     }
   }
   .input.textarea {


### PR DESCRIPTION
Hi,
it's a fix for search field reset icon ( see #18 ). I tested on Safari and Chrome Mac.

I add a _padding-right: 0_ for _.field .input.search_ in sass/ui/_forms.scss
