### PR TITLE
Windows Phone dropdown navbar

### DIFF
--- a/js/libs/gumby.init.js
+++ b/js/libs/gumby.init.js
@@ -2,9 +2,14 @@
 * Gumby Init
 */
 
+// test for Windows Phone
+Modernizr.addTest('windowsphone', function() {
+	return window.navigator.userAgent.indexOf("Windows Phone") > 0; 
+});
+
 // test for touch event support
 Modernizr.load({
-	test: Modernizr.touch,
+	test: Modernizr.touch || Modernizr.windowsphone,
 
 	// if present load custom jQuery mobile build and update Gumby.click
 	yep: Gumby.path+'/jquery.mobile.custom.min.js',

--- a/js/libs/ui/gumby.navbar.js
+++ b/js/libs/ui/gumby.navbar.js
@@ -9,8 +9,8 @@
 
 	// define and init module on touch enabled devices only
 	// when we are at tablet size or smaller
-	if(!Modernizr.touch || $(window).width() > Gumby.breakpoint) {
-
+	if( (!Modernizr.touch || $(window).width() > Gumby.breakpoint)
+			&& !Modernizr.windowsphone ) {
 		// add Gumby no touch class
 		$html.addClass('gumby-no-touch');
 		return;
@@ -41,12 +41,14 @@
 
 		// on mousemove and touchstart toggle modernizr classes and disable/enable this module
 		// workaround for Pixel and other multi input devices
-		$(window).on('mousemove touchstart', function(e) {
-			e.stopImmediatePropagation();
-			if(e.type === 'mousemove') {
-				scope.$dropDowns.on('mouseover mouseout', scope.toggleDropdown);
-			}
-		});
+		if( !Modernizr.windowsphone ) {
+			$(window).on('mousemove touchstart', function(e) {
+				e.stopImmediatePropagation();
+				if(e.type === 'mousemove') {
+					scope.$dropDowns.on('mouseover mouseout', scope.toggleDropdown);
+				}
+			});	
+		}
 	}
 
 	Navbar.prototype.toggleDropdown = function(e) {


### PR DESCRIPTION
Should fix #4.

Added check for Windows Phone in gumby.init.js

Windows Phone uses click events and touch events.
The "mousemove touchstart" toggling was causing problems, so I added a check to only include that when not on Windows Phone.
