### PR TITLE
Added check to see if original checkbox is checked as well as keeping the check to see if the label has the checked class.

### DIFF
--- a/js/libs/ui/gumby.checkbox.js
+++ b/js/libs/ui/gumby.checkbox.js
@@ -38,7 +38,7 @@
 		});
 
 		// update any .checked checkboxes on load
-		if(scope.$el.hasClass('checked')) {
+		if(this.$input.prop('checked') || scope.$el.hasClass('checked')) {
 			scope.update(true);
 		}
 	}


### PR DESCRIPTION
Add an extra condition to the original initialisation if, to check to see if the original checkbox is checked.

This is useful for edit forms created by frameworks or templates where checking the value before the html is rendered would be problematic or cause lots of duplicate code, it also allows adds extra portability to the code between applications.
