### PR TITLE
New Icon Function

### DIFF
--- a/sass/ui/_icons.scss
+++ b/sass/ui/_icons.scss
@@ -23,7 +23,7 @@ i[class*=" icon-"] {
   text-align: center;
 }
 
-@each $icon in $entypo-icons {
+/* @each $icon in $entypo-icons {
   .#{nth($icon, 1)} {
     &.icon-left a:before, &.icon-right a:after {
       content: "#{nth($icon, 2)}";
@@ -34,4 +34,28 @@ i[class*=" icon-"] {
     content: "#{nth($icon, 2)}";
     height: inherit;
   }
+} */
+
+@function match($list, $icon) {
+    @each $item in $list {
+        $index: index($item, $icon);
+        @if $index { 
+            $return: if($index == 1, 2, $index);
+            @return nth($item, $return); 
+        }
+    }
+    @return false;
+}
+
+@mixin icon($icon) {
+    .#{$icon} {
+        &.icon-left a:before, &.icon-right a:after {
+            content: "#{match($entypo-icons, $icon)}";
+            height: inherit;
+        }
+    }
+    i.#{$icon}:before {
+        content: "#{match($entypo-icons, $icon)}";
+        height: inherit;
+    }
 }


### PR DESCRIPTION
Added a function to allow user to use a mixin to insert a single icon into compiled CSS instead of the full icon list, therefore allowing customization without editing _entypo.scss icon list.
