### PR TITLE
Radio button triggers onChange instead of OnCheck

### DIFF
--- a/js/libs/ui/gumby.radiobtn.js
+++ b/js/libs/ui/gumby.radiobtn.js
@@ -63,9 +63,9 @@
 		this.$input.prop('checked', true);
 		$span.append('<i class="icon-dot" />');
 
-		Gumby.debug('Triggering onCheck event', this.$el);
+		Gumby.debug('Triggering onChange event', this.$el);
 
-		this.$el.addClass('checked').trigger('gumby.onCheck');
+		this.$el.addClass('checked').trigger('gumby.onChange');
 	};
 
 	// add initialisation


### PR DESCRIPTION
The radio button class has some confusion on what events it is supposed to export and trigger.  I opted to use the onChange event because the radiobtn module was already exporting it, but if you prefer onCheck that would be fine too.

On a related note, the docs at http://gumbyframework.com/docs/javascript/#!/events-initialization use Gumby.onChange (with a capital G), but I think the ui modules are using gumby with a lowercase g.

I made this edit on a modified fork of gumby and just thought I'd toss the pull request out there to raise awareness of these differences, feel free to close this request if needed.
