### PR TITLE
changed $parent to $context in second if

### DIFF
--- a/sass/functions/_em.scss
+++ b/sass/functions/_em.scss
@@ -5,7 +5,7 @@
       $size-in-px: strip-units($size-in-px);
   }
   @if not unitless($context) {
-      $parent: strip-units($context);
+      $context: strip-units($context);
   }
   @return ($size-in-px / $context) * 1em;
 }


### PR DESCRIPTION
When using a variable for $context in the function parameters that contained units, it wasn't able to do the return because $context wasn't being redefined sans units.
