### PR TITLE
Add possibility to follow href path in tabs

### DIFF
--- a/js/libs/ui/gumby.tabs.js
+++ b/js/libs/ui/gumby.tabs.js
@@ -10,7 +10,7 @@
 		Gumby.debug('Initializing Tabs', $el);
 
 		this.$el = $el;
-		this.$nav = this.$el.find('ul.tab-nav:not(follow-href-path) > li');
+		this.$nav = this.$el.find('ul.tab-nav:not(.follow-href-path) > li');
 		this.$content = this.$el.find('.tab-content');
 
 		var scope = this;


### PR DESCRIPTION
Hi,

For my project I need tabs, but also the possibility to follow href path in tabs. I don't want Gumby to change the content of `tab-content` elements.

With the short modification, when you use: 

```
<ul class="tab-nav follow-href-path">
     <li><a href="http://example.com"> ... </a></li>
</ul>
```

the JS will not initialize tabs, and, if you click on a `a` link into the tab, you will follow the link ! 

I am not sure all browser will accept it, but with Firefox (the one I must use), it does the job ! I will let you decide the opportunity to merge my pull request. I just share :-)
