### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Gumby has a few dependencies. Big thank you to the innovative geniuses behind th
 
 - [Sass](https://github.com/nex3/sass) - Nathan Weizenbaum
 - [Compass](https://github.com/chriseppstein/compass) - Chris Eppstein
-- [Modular Scale](https://github.com/Team-Sass/modular-scale) - Scott Kellum
+- [Modular Scale](https://github.com/Team-Sass/modular-scale) - Scott Kellum  *Note: Please use modular scale 1.0.6, 2.x has not been integrated yet*
 - [FitText](http://fittextjs.com/) - Paravel
 - [jQuery](http://jquery.com/)
 - [Modernizr](http://modernizr.com/)


### PR DESCRIPTION
Added note about using 1.0.6 modular scale if you are installing it via a gem.

When trying to build this, I just install the modular scale gem and it defaulted to 2.x.  This caused build problems when compiling.  A basic note would have saved me some time.  Hopefully it will save others time as well.
