### PR TITLE
Actually use the header-link-hover-color variable.

### DIFF
--- a/css/gumby.css
+++ b/css/gumby.css
@@ -637,6 +637,7 @@ html, body { height: 100%; }
 /* Typography */
 h1, h2, h3, h4, h5, h6 { font-family: "Open Sans"; font-weight: 300; color: #444444; text-rendering: optimizeLegibility; padding-top: 0.252em; line-height: 1.0665em; padding-bottom: 0.252em; }
 h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { color: #d04526; }
+h1 a:hover, h2 a:hover, h3 a:hover, h4 a:hover, h5 a:hover, h6 a:hover { color: #c03d20; }
 
 @media only screen and (max-width: 767px) { h1, h2, h3, h4, h5, h6 { word-wrap: break-word; } }
 h1 { font-size: 67.77709px; font-size: 4.23607rem; }

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -10,6 +10,9 @@ h1,h2,h3,h4,h5,h6 {
   @include padding-trailer($rhythm-spacing);
   a {
     color: $header-link-color;
+    &:hover {
+      color: $header-link-hover-color;
+    }
   }
 }
 


### PR DESCRIPTION
I see a `$header-link-hover-color` defined [here](https://github.com/GumbyFramework/Gumby/blob/d4093cb734b54ef649cdd06fb78e6e53d8c20b55/sass/var/_settings.scss#L71), however it doesn't work as I would expect. In fact, I don't see it used anywhere else. I suspect it went unnoticed because by default it is the same value as `$body-link-hover-color`.

I have simply added what I expect was it's intended usage (changing the color of header links while hovering).