### PR TITLE
Navbar hover colors should be relative to navbar

### DIFF
--- a/sass/ui/_navbar.scss
+++ b/sass/ui/_navbar.scss
@@ -343,7 +343,7 @@
 .gumby-no-touch .navbar ul li:hover > a,
 .gumby-touch .navbar ul li.active > a {
   position: relative;
-  background: $info-hover-color;
+  background: darken($navbar-color, 12%);
   z-index: 1000;
 }
 


### PR DESCRIPTION
Making the hover color the same as the `$info-hover` doesn't seem to make much sense IMO.