### PR TITLE
Adding <select multiple> styles

### DIFF
--- a/sass/ui/_forms.scss
+++ b/sass/ui/_forms.scss
@@ -390,3 +390,35 @@ label + {
   }
 }
 
+/* Form Multi-picker Element (<select> multiple) */
+.multi-picker {
+  position: relative;
+  width: auto;
+  display: inline-block;
+  margin: 0 0 2px 1.2%;
+  overflow: hidden;
+  border: 1px solid darken($default-color, 5%);
+  @include border-radius(4px);
+  font-family: $font-family;
+  font-weight: $font-weight-semibold;
+  height: auto;
+  &:first-child {
+    margin-left: 0;
+  }
+  select[multiple] {
+    position: relative;
+    display: block;
+    min-width: 100%;
+    width: 100%;
+    height: auto;
+    padding: 6px 20px 6px 15px;
+    color: $body-font-color;
+    border: none;
+    background: #fff;
+    outline: none;
+    -webkit-appearance: none;
+    z-index: 99;
+    cursor: pointer;
+    @include font-size($norm);
+  }
+}


### PR DESCRIPTION
I am using Gumby in a new project and while updating HTML elements such as radio buttons, check boxes, and select elements I found that multi selects were not part of the Gumby UI demo.  I checked the CSS files and found no styling other than '.picker select'.  Prefacing the &lt;select&gt; elements with the 'picker' class triggers Gumby's design updates to the select (making multi-selects appear like drop down selects) so instead I think a new class of 'multi-picker' could help and be used as the wrapper for multi-selects instead of 'picker'.

Select "Picker" Example:
&lt;div class="picker"&gt;
    &lt;select&gt;
        &lt;option value="#" disabled=""&gt;Favorite Dalek phrase...&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
    &lt;/select&gt;
&lt;/div&gt;

Select "Multi-Picker" Example:
&lt;div class="multi-picker"&gt;
    &lt;select multiple="multiple"&gt;
        &lt;option value="#" disabled=""&gt;Favorite Dalek phrase...&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
        &lt;option&gt;EXTERMINATE&lt;/option&gt;
    &lt;/select&gt;
&lt;/div&gt;

The proposed styles attempt to use many of the same styles already used in Gumby's UI for &lt;select&gt; differing only where needed such as background-image/color, padding, etc.